### PR TITLE
Fix riuso key in publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -25,8 +25,6 @@ maintenance:
 legal:
   license: Apache-2.0
   repoOwner: Comune di Trento
-  riuso:
-    codiceIPA: c_l378
 intendedAudience:
   countries:
     - it
@@ -49,6 +47,8 @@ it:
     cie: false
     pagopa: false
     spid: false
+  riuso:
+    codiceIPA: c_l378
 description:
   it:
     features:


### PR DESCRIPTION
Questa PR:
* risolve il problema con la chiave `riuso` spostandola nella sezione `it`

Resto a disposizione, grazie @jekfioroni 